### PR TITLE
refactor: JWT subject 지정

### DIFF
--- a/src/main/java/com/example/jjangushrine/config/security/jwt/JwtFilter.java
+++ b/src/main/java/com/example/jjangushrine/config/security/jwt/JwtFilter.java
@@ -64,7 +64,7 @@ public class JwtFilter extends OncePerRequestFilter {
             String jwt = extractToken(bearerJwt);
             Claims claims = jwtUtil.extractClaims(jwt);
 
-            Long userId = claims.get("id", Long.class);
+            Long id = Long.parseLong(claims.getSubject());
             String email = claims.get("email", String.class);
             UserRole role = UserRole.of(claims.get("role", String.class));
 
@@ -74,13 +74,13 @@ public class JwtFilter extends OncePerRequestFilter {
             CustomUserDetails userDetails;
             if (role == UserRole.USER) {
                 User user = User.builder()
-                        .id(userId)
+                        .id(id)
                         .email(email)
                         .build();
                 userDetails = new CustomUserDetails(user);
             } else {
                 Seller seller = Seller.builder()
-                        .id(userId)
+                        .id(id)
                         .email(email)
                         .build();
                 userDetails = new CustomUserDetails(seller);

--- a/src/main/java/com/example/jjangushrine/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/example/jjangushrine/config/security/jwt/JwtUtil.java
@@ -31,7 +31,7 @@
             Date now = new Date();
 
             return SecurityConst.BEARER_PREFIX + Jwts.builder()
-                    .claim("id", principal.getId())
+                    .subject(principal.getId().toString())
                     .claim("email", principal.getUsername())
                     .claim("role", principal.getRole().name())
                     .issuedAt(now)


### PR DESCRIPTION
- principal(CustomUserDetails)에 저장된 id를 Subjetct로 지정 
   ( 기존엔 Subject없이 Claim으로만 처리 )
- 필터의 userId 변수명을 id로 변경 
   ( 가독성을 위해 변경 )