### PR TITLE
refactor: Auth API의 응답 구조를 ApiResponse 형식으로 변경

### DIFF
--- a/src/main/java/com/example/jjangushrine/common/ApiResMessage.java
+++ b/src/main/java/com/example/jjangushrine/common/ApiResMessage.java
@@ -1,0 +1,7 @@
+package com.example.jjangushrine.common;
+
+public class ApiResMessage {
+    // 회원 관련 성공 메시지
+    public static final String SIGNUP_SUCCESS = "회원가입이 성공적으로 완료되었습니다.";
+    public static final String LOGIN_SUCCESS = "로그인이 성공적으로 완료되었습니다.";
+}

--- a/src/main/java/com/example/jjangushrine/common/ApiResponse.java
+++ b/src/main/java/com/example/jjangushrine/common/ApiResponse.java
@@ -23,9 +23,4 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> success(String message) {
         return new ApiResponse<>(true, message, null);
     }
-
-    // 에러 응답
-    public static <T> ApiResponse<T> error(String message) {
-        return new ApiResponse<>(false, message, null);
-    }
 }

--- a/src/main/java/com/example/jjangushrine/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/jjangushrine/domain/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.example.jjangushrine.domain.auth.controller;
 
+import com.example.jjangushrine.common.ApiResponse;
+import com.example.jjangushrine.common.ApiResMessage;
 import com.example.jjangushrine.domain.auth.dto.request.SellerSignUpReq;
 import com.example.jjangushrine.domain.auth.dto.request.SignInReq;
 import com.example.jjangushrine.domain.auth.dto.request.UserSignUpReq;
@@ -23,36 +25,44 @@ public class AuthController {
     private final UserAuthService userAuthService;
     private final SellerAuthService sellerAuthService;
 
-    @PostMapping("user/signup")
-    public ResponseEntity<Void> userSignUp(
+    @PostMapping("/user/signup")
+    public ResponseEntity<ApiResponse<Void>> userSignUp(
             @RequestBody @Valid UserSignUpReq userSignUpReq
     ) {
         userAuthService.userSignUp(userSignUpReq);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(ApiResMessage.SIGNUP_SUCCESS));
     }
 
-    @PostMapping("seller/signup")
-    public ResponseEntity<Void> sellerSignUp(
+    @PostMapping("/seller/signup")
+    public ResponseEntity<ApiResponse<Void>> sellerSignUp(
             @RequestBody @Valid SellerSignUpReq sellerSignUpReq
     ) {
         sellerAuthService.sellerSignUp(sellerSignUpReq);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(ApiResMessage.SIGNUP_SUCCESS));
     }
 
-    @PostMapping("user/signin")
-    public ResponseEntity<SignInRes> userSignIn(
+    @PostMapping("/user/signin")
+    public ResponseEntity<ApiResponse<SignInRes>> userSignIn(
             @RequestBody @Valid SignInReq signInReq
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(userAuthService.userSignIn(signInReq));
+                .body(ApiResponse.success(
+                        ApiResMessage.LOGIN_SUCCESS,
+                        userAuthService.userSignIn(signInReq)
+                        ));
     }
 
-    @PostMapping("seller/signin")
-    public ResponseEntity<SignInRes> sellerSignIn(
+    @PostMapping("/seller/signin")
+    public ResponseEntity<ApiResponse<SignInRes>> sellerSignIn(
             @RequestBody @Valid SignInReq signInReq
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(sellerAuthService.sellerSignIn(signInReq));
+                .body(ApiResponse.success(
+                        ApiResMessage.LOGIN_SUCCESS,
+                        sellerAuthService.sellerSignIn(signInReq)
+                ));
     }
 }
 

--- a/src/main/java/com/example/jjangushrine/domain/auth/dto/response/SignInRes.java
+++ b/src/main/java/com/example/jjangushrine/domain/auth/dto/response/SignInRes.java
@@ -1,6 +1,6 @@
 package com.example.jjangushrine.domain.auth.dto.response;
 
 public record SignInRes(
-        String bearerToken
+        String accessToken
 ) {
 }


### PR DESCRIPTION
**refactor: 응답 성공 메시지 상수 클래스 추가**
- ApiResponse: ErrorResponse 사용으로 불필요해진 ApiResponse.error 메서드 삭제
- ApiResMessage 클래스 추가

**refactor: Auth API의 응답 구조를 ApiResponse 형식으로 변경**
- SignInRes 변수명 bearerToken → accessToken
 (좀 더 직관적인 변수명 사용)
- 경로 path 시작 부분에 / 추가
 (일관성 있는 URL 구조를 위해서)